### PR TITLE
Moved CORS proxy from Heroku to Vercel hosting

### DIFF
--- a/solarize-v1/cors-2021/api/index.js
+++ b/solarize-v1/cors-2021/api/index.js
@@ -8,13 +8,14 @@ const Axios = require ( "axios" ).default;
 
 // Express middleware
 app.use ( express.json () );
-app.use ( ( request, response, next) => {
+app.use ( ( _, response, next ) => {
 
     // Sets up CORS Proxy
     response.header('Access-Control-Allow-Credentials', 'true');
     response.header('Access-Control-Allow-Origin', '*');
     response.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
     response.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Authorization, Accept, Set-Cookie, *');
+	response.setHeader('Cache-Control', 's-max-age=1, stale-while-revalidate');
     next ();
 
 });
@@ -23,27 +24,18 @@ app.get ( "/proxy/:url", async ( request, response ) => {
 
     // Checks that the URL query param has been passed
     if ( !request.params.url ) {
-
         response.sendStatus ( 400 );
-
     }
 
     // Fetches data
     Axios.get ( request.params.url )
     .then ( ( result ) => {
-
         response.status ( 200 ).json ( result.data );
-
     })
     .catch ( ( error ) => {
-
         response.status ( error.response.status || 500 ).json ( error.response.data );
+    });
 
-    })
-
-})
-
-// Listens for requests
-app.listen ( process.env.PORT || 5000, () => {
-    console.log ( "[PROXY/STATUS]: Proxy online!" );
 });
+
+module.exports = app;

--- a/solarize-v1/cors-2021/proxy.js
+++ b/solarize-v1/cors-2021/proxy.js
@@ -38,4 +38,8 @@ app.get ( "/proxy/:url", async ( request, response ) => {
 
 });
 
+app.listen ( 5000, () => {
+	console.log ( "[ONLINE]: Proxy online at port 5000" );
+});
+
 module.exports = app;

--- a/solarize-v1/cors-2021/vercel.json
+++ b/solarize-v1/cors-2021/vercel.json
@@ -1,0 +1,15 @@
+{
+	"version": 2,
+	"builds": [
+		{
+			"src": "proxy.js",
+			"use": "@now/node"
+		}
+	],
+	"routes": [
+		{
+			"src": "/(.*)",
+			"dest": "proxy.js"
+		}
+	]
+}

--- a/solarize-v1/cors-2021/vercel.json
+++ b/solarize-v1/cors-2021/vercel.json
@@ -3,7 +3,7 @@
 	"builds": [
 		{
 			"src": "proxy.js",
-			"use": "@now/node"
+			"use": "@vercel/node"
 		}
 	],
 	"routes": [


### PR DESCRIPTION
Took a couple of tries due to conflicting documentation, but the proxy is now online at [https://solarize-v1-proxy.vercel.app](https://solarize-v1-proxy.vercel.app). 

This CORS proxy is now useless since the CORS policy has now been updated, but this was a necessary proxy during the hackathon in 2021. Thus to keep somewhat intact (_and live_) record of the original source code, we are keeping the proxy.

This hosting move had to be done since Heroku is shutting down all free instances this year. 